### PR TITLE
Remove "bottle :unneeded" as it is deprecated

### DIFF
--- a/skpr.rb
+++ b/skpr.rb
@@ -6,7 +6,6 @@ class Skpr < Formula
   desc "CLI for the Skpr Hosting Platform"
   homepage "https://www.skpr.io"
   version "0.14.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Issue #1 :
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the skpr/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/skpr/homebrew-taps/skpr.rb:9
```
after `brew update`.
<img width="809" alt="Screen Shot 2022-02-28 at 9 57 53 am" src="https://user-images.githubusercontent.com/5859926/155903537-2b55838f-51fb-47f5-878c-ca8176534dfe.png">